### PR TITLE
Use Mean of All Peer Gradients Instead of First Gradient

### DIFF
--- a/src/tplr/comms.py
+++ b/src/tplr/comms.py
@@ -892,7 +892,9 @@ class Comms(ChainManager):
                 state_dict_resp[param_name].dtype if state_dict_resp else torch.float32  # type: ignore
             )
             # Convert back to original dtype
-            final_state_dict[param_name] = tensors[0].to(orig_dtype)  # type: ignore
+            stacked = torch.stack([t.to(torch.float32) for t in tensors], dim=0)
+            mean_t = stacked.mean(dim=0) 
+            final_state_dict[param_name] = mean_t.to(orig_dtype)
 
         # Create result namespace
         result = SimpleNamespace(


### PR DESCRIPTION
## Summary
This PR changes the final gradient aggregation step from selecting only the first peer’s gradient to computing the mean across **all** peers’ gradients. Previously, the code did:
```python
final_state_dict[param_name] = tensors[0].to(orig_dtype)
```
which effectively ignored the rest of the peers. Now, it does:
```python
stacked = torch.stack([t.to(torch.float32) for t in tensors], dim=0)
mean_t = stacked.mean(dim=0)
final_state_dict[param_name] = mean_t.to(orig_dtype)
```
ensuring every peer’s contribution is incorporated.

## Why This Change?
- **Better Model Updates**: Averaging all gradients from peers captures more comprehensive information, leading to more stable and accurate updates.
- **Proper Distributed Training**: True multi-peer training requires each peer’s gradient to be factored in, rather than taking one arbitrary gradient.
- **Improved Convergence**: Empirically, averaging typically yields smoother loss curves and better final performance than using a single gradient.

## Impact
- Should result in improved training stability and convergence, especially in large-scale distributed settings.
- Minor additional compute for stacking/averaging, but this is negligible compared to the overall training cost.

## Testing & Verification
- Locally tested to confirm that the mean operation performs as expected and that the code runs without errors.
- Will monitor loss curves to verify improved stability and gather feedback from validator scoring.