### PR TITLE
Refactor Checkpoint Loading/Saving Flow for miners.

### DIFF
--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -454,6 +454,25 @@ class Miner:
             self.window_step += 1
             tplr.logger.info(f"Total optimization steps: {self.global_step}")
 
+            # Save checkpoint logic
+            if self.global_step % self.hparams.checkpoint_frequency == 0:
+                tplr.logger.info(f"Creating checkpoint at global_step {self.global_step}")
+                
+                # asyncio checkpoint saving task
+                asyncio.create_task(
+                    self.comms.save_checkpoint(
+                        model=self.model,
+                        optimizer=self.optimizer,
+                        scheduler=self.scheduler,
+                        momentum=self.momentum,
+                        global_step=self.global_step,
+                        current_window=self.current_window,
+                        start_window=self.start_window
+                    )
+                )
+            else:
+                tplr.logger.info("Skipping checkpoint save this round")
+
     # Listens for new blocks and sets self.current_block and self.current_window
     def block_listener(self, loop):
         def handler(event, _u, _s):


### PR DESCRIPTION
## Description  
This PR updates the checkpoint mechanism in the `miner` and `comms` modules to provide a cleaner, more reliable way of saving and restoring checkpoints. The key improvements include:  

### Modified `s3_get_object`  
- Fixed the endpoint URL creation by passing `bucket.account_id` instead of `bucket.name`, ensuring we connect to the correct Cloudflare R2 endpoint.  

### Refactored `get_latest_checkpoint`  
- Changed the checkpoint retrieval order to:  
  1. First try retrieving from the **highest-stake validator’s bucket**.  
  2. Then fall back to the **miner’s own R2 bucket**.  
  3. Finally, use **local storage** if the first two checks fail.  
- This ensures we always attempt to load from the most **up-to-date (validator) source**, then fall back to local options if needed.  

### Consolidated `save_checkpoint`  
- Uses a **single function** to handle both local and R2 uploads.  
- Reduces code duplication and ensures **consistent checkpoint data** is stored in both locations, including:  
  - `model_state_dict`  
  - `optimizer_state_dict`  
  - `scheduler_state_dict`  
  - `momentum`  
  - `global_step`  
- Improves maintainability and ensures **uniform checkpoint integrity** across different storage options.  

### Ensured Compatibility in `miner.py`  
- Adjusted checkpoint saving calls and parameter passing (`start_window`, `current_window`) to be consistent with changes in `comms.py`.  
- The `load_checkpoint` call now correctly **initializes momentum and global step** if a checkpoint is found, or starts from scratch otherwise.  

### Summary  
These changes **streamline** the workflow for checkpoint saving and loading, making the miner **more robust and consistent** during restarts.  

If you have any questions or feedback on this PR, please let me know!  
