### PR TITLE
Add GitHub workflow to run pytest

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+name: Run Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Install uv and set the python version
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install the project
+        run: uv sync --all-extras --dev
+
+      - name: Run Pytest
+        env:
+          R2_GRADIENTS_ACCOUNT_ID: ${{ secrets.R2_GRADIENTS_ACCOUNT_ID }}
+          R2_GRADIENTS_BUCKET_NAME: ${{ secrets.R2_GRADIENTS_BUCKET_NAME }}
+          R2_GRADIENTS_READ_ACCESS_KEY_ID: ${{ secrets.R2_GRADIENTS_READ_ACCESS_KEY_ID }}
+          R2_GRADIENTS_READ_SECRET_ACCESS_KEY: ${{ secrets.R2_GRADIENTS_READ_SECRET_ACCESS_KEY }}
+          R2_GRADIENTS_WRITE_ACCESS_KEY_ID: ${{ secrets.R2_GRADIENTS_WRITE_ACCESS_KEY_ID }}
+          R2_GRADIENTS_WRITE_SECRET_ACCESS_KEY: ${{ secrets.R2_GRADIENTS_WRITE_SECRET_ACCESS_KEY }}
+          R2_DATASET_ACCOUNT_ID: ${{ secrets.R2_DATASET_ACCOUNT_ID }}
+          R2_DATASET_BUCKET_NAME: ${{ secrets.R2_DATASET_BUCKET_NAME }}
+          R2_DATASET_READ_ACCESS_KEY_ID: ${{ secrets.R2_DATASET_READ_ACCESS_KEY_ID }}
+          R2_DATASET_READ_SECRET_ACCESS_KEY: ${{ secrets.R2_DATASET_READ_SECRET_ACCESS_KEY }}
+          R2_DATASET_WRITE_ACCESS_KEY_ID: ${{ secrets.R2_DATASET_WRITE_ACCESS_KEY_ID }}
+          R2_DATASET_WRITE_SECRET_ACCESS_KEY: ${{ secrets.R2_DATASET_WRITE_SECRET_ACCESS_KEY }}
+        run: uv run pytest


### PR DESCRIPTION
Closes #49 

## Add GitHub Actions Workflow for Running Tests

### Summary
This PR introduces a GitHub Actions workflow to automatically run tests on every push to the `main` branch and for every pull request. The workflow runs tests on **Python 3.11 and 3.12** using `pytest`.

### Changes Introduced
- Added a **`Run Tests`** workflow in `.github/workflows/test.yml`.
- The workflow:
  - Runs on `ubuntu-latest`.
  - Installs project dependencies using `uv`.
  - Runs tests with `pytest`.
  - Uses GitHub secrets for credentials.

### Required GitHub Secrets
To ensure the tests can access the required resources, these secrets must be set in your GitHub repository:

#### Gradient Storage
- `R2_GRADIENTS_ACCOUNT_ID`
- `R2_GRADIENTS_BUCKET_NAME`
- `R2_GRADIENTS_READ_ACCESS_KEY_ID`
- `R2_GRADIENTS_READ_SECRET_ACCESS_KEY`
- `R2_GRADIENTS_WRITE_ACCESS_KEY_ID`
- `R2_GRADIENTS_WRITE_SECRET_ACCESS_KEY`

#### Dataset Storage
- `R2_DATASET_ACCOUNT_ID`
- `R2_DATASET_BUCKET_NAME`
- `R2_DATASET_READ_ACCESS_KEY_ID`
- `R2_DATASET_READ_SECRET_ACCESS_KEY`
- `R2_DATASET_WRITE_ACCESS_KEY_ID`
- `R2_DATASET_WRITE_SECRET_ACCESS_KEY`

Once these secrets are in place, the workflow will install dependencies and run tests against the specified environments.