### PR TITLE
feat/limit gather peers

### DIFF
--- a/hparams.json
+++ b/hparams.json
@@ -29,6 +29,7 @@
     "validator_offset": 1,
     "checkpoint_frequency": 100,
     "topk_peers": 20,
+    "max_topk_peers": 15,
     "minimum_peers": 5,
     "active_check_interval": 60,
     "recent_windows": 5,

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -1063,8 +1063,7 @@ class Validator:
                 tplr.logger.error(
                     "Failed to gather gradients from peers. Waiting for next window."
                 )
-                while self.current_window == self.sync_window:
-                    await asyncio.sleep(0.1)
+                self.global_step += 1
                 continue
             tplr.logger.info(f"Skipped UIDs: {gather_result.skipped_uids}")
             tplr.logger.info(

--- a/src/tplr/chain.py
+++ b/src/tplr/chain.py
@@ -481,10 +481,10 @@ class ChainManager:
         ]
         miner_incentives.sort(key=lambda x: x[1], reverse=True)
 
-        # Calculate number of peers based on topk percentage
-        n_topk_peers = max(
-            1, int(len(miner_incentives) * (self.hparams.topk_peers / 100))
-        )
+        # Determine the number of top-k peers based on percentage
+        n_topk_peers = int(len(miner_incentives) * (self.hparams.topk_peers / 100))
+        n_topk_peers = min(max(n_topk_peers, 1), self.hparams.max_topk_peers)
+
         n_peers = max(self.hparams.minimum_peers, n_topk_peers)
 
         # Take top n_peers by incentive for gradient gathering


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->

- **feat: limit the gather peers to 15**
- **fix: increment global step on gather failure**

This is a suggestion to limit the gather to maximum 15 peers. This would
hopefully free up some network usage and make it more reliable with gather and
putting. Moreover, I noticed the validator will not increase the global step if
gather result is None. I think it should always as it does in other parts of
the code when something goes wrong.


## Related Issue(s)

None

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

Changes maximum number of gather peers.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.
