### PR TITLE
Initialize binary moving average to 0.5

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -193,8 +193,8 @@ class Validator:
         self.relative_improvement_random = 0.0
         self.valid_score_indices = []
         self.gradient_scores = torch.zeros(self.metagraph.n, dtype=torch.float32)
-        self.binary_indicator_scores = torch.full(
-            (self.metagraph.n,), 0.5, dtype=torch.float32
+        self.binary_indicator_scores = torch.zeros(
+            self.metagraph.n, dtype=torch.float32
         )
         self.gradient_moving_avg_scores = torch.zeros(
             self.metagraph.n, dtype=torch.float32
@@ -202,7 +202,9 @@ class Validator:
         self.final_moving_avg_scores = torch.zeros(
             self.metagraph.n, dtype=torch.float32
         )
-        self.binary_moving_averages = torch.zeros(self.metagraph.n, dtype=torch.float32)
+        self.binary_moving_averages = torch.full(
+            (self.metagraph.n,), 0.5, dtype=torch.float32
+        )
         self.weights = torch.zeros(self.metagraph.n, dtype=torch.float32)
         self.normalised_binary_moving_averages = torch.zeros(
             self.metagraph.n, dtype=torch.float32


### PR DESCRIPTION
Additionally, initialize the binary indicator to 0.

## MOTIVATION

This commit achieves what was initially intended when the initial value
of the binary indicator was changed from 0 to 0.5, namely reducing the
time it takes for a good miner to get incentives. The binary moving
average for good miners typically converges to around 0.8, and it
currently takes around 3k steps which currently amounts to around 70h.
This is unnecessarily long.

### BEFORE (initial binary moving average = 0)
Initializing the binary indicator to 0.5 instead of 0 does nothing to
reduce the time it takes for a good miner to get incentives. This is
because the first time the binary moving average is updated, the new
binary indicator value is used (-1 or 1), meaning, the 0.5 initial value
is never used to calculate the binary moving average. Hence it's safe to
initialize the binary indicator to 0.

### AFTER (initial binary moving average = 0.5)
The binary moving average starts at 0.5 and reaches 0.8 nearly twice as
fast.
