### PR TITLE
Don't reward negative scores

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -845,7 +845,7 @@ class Validator:
                     )
                     # Calculate final score incorporating both metrics
                     final_score = (
-                        self.gradient_scores[eval_uid]
+                        max(0, self.gradient_scores[eval_uid])
                         * self.normalised_binary_moving_averages[eval_uid]
                     )
                     tplr.logger.debug(


### PR DESCRIPTION
The final score is positive if both the gradient score and the
normalized binary moving average are negative. It makes no sense, as we
want both of these to be positive and the larger the better.

Furthermore, it's easily exploited:
1. Upload zero gradients until the normalized binary score is at its
   minimum (-0.5).
2. Then, start uploading random gradients. They will get very negative
   gradient scores. Very negative times -0.5 is very positive. Final
   score approaches inf and weight approaches 1.
3. Enjoy your profits until the normalized binary score gets close to
   zero, then repeat from step 1.

Proof. Final score and weight are positive when both gradient score and normalized binary scores are negative.
<img width="1122" alt="proof" src="https://github.com/user-attachments/assets/72da3e53-cf47-467d-831f-3035c8586a1c" />