### PR TITLE
Fix UID Type Mismatch in Moving Average Score Lookup

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -442,7 +442,7 @@ class Validator:
                 tplr.logger.info(
                     f"No gradient gathered from UID {uid}. Slashing moving average score by 50%."
                 )
-                if int(uid) in self.final_moving_avg_scores:
+                if 0 <= uid < self.final_moving_avg_scores.size(0):
                     old_score = self.final_moving_avg_scores[uid].item()
                     self.final_moving_avg_scores[uid] *= 0.5  # Apply 50% reduction
                     new_score = self.final_moving_avg_scores[uid].item()

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -442,7 +442,7 @@ class Validator:
                 tplr.logger.info(
                     f"No gradient gathered from UID {uid}. Slashing moving average score by 50%."
                 )
-                if uid in self.final_moving_avg_scores:
+                if int(uid) in self.final_moving_avg_scores:
                     old_score = self.final_moving_avg_scores[uid].item()
                     self.final_moving_avg_scores[uid] *= 0.5  # Apply 50% reduction
                     new_score = self.final_moving_avg_scores[uid].item()


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [/] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

Ensure uid is cast to int before checking final_moving_avg_scores keys, preventing lookup errors caused by str type UIDs in skipped_uids.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [/] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
