### PR TITLE
Replace EMA with Sliding Window for Final Moving Average Scores

### DIFF
--- a/hparams.json
+++ b/hparams.json
@@ -14,6 +14,7 @@
     "gradient_score_ma_alpha": 0.6,
     "binary_score_ma_alpha": 0.05,
     "final_score_ma_alpha": 0.75,
+    "moving_average_window": 5,
     "tokenizer_name": "togethercomputer/LLaMA-2-7B-32K",
     "hidden_size": 2048,
     "num_hidden_layers": 16,

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -244,6 +244,9 @@ class Validator:
         self.inactive_scores = {}  # {uid: (last_active_window, last_score)}
         self.inactivity_slash_rate = 0.25  # 25% slash per window
 
+        # Initialize final score history (for sliding-window averaging)
+        self.final_score_history = defaultdict(list)
+
     async def run(self):
         # Start background block listener
         self.loop = asyncio.get_running_loop()
@@ -1049,19 +1052,17 @@ class Validator:
                         max(0, self.gradient_scores[eval_uid])
                         * self.normalised_binary_moving_averages[eval_uid]
                     )
-                    tplr.logger.debug(
-                        f"Final Score : {self.final_moving_avg_scores[eval_uid]}"
-                    )
-
-                    # Ensure moving average score is non-negative
-                    self.final_moving_avg_scores[eval_uid] = max(
-                        self.hparams.final_score_ma_alpha
-                        * self.final_moving_avg_scores[eval_uid]
-                        + (1 - self.hparams.final_score_ma_alpha) * final_score,
-                        0.0,
+                    tplr.logger.debug(f"Computed Final Score for UID {eval_uid}: {final_score}")
+                    
+                    # Sliding window update for the final moving average score
+                    self.final_score_history[eval_uid].append(final_score)
+                    if len(self.final_score_history[eval_uid]) > self.hparams.moving_average_window:
+                        self.final_score_history[eval_uid].pop(0)
+                    self.final_moving_avg_scores[eval_uid] = (
+                        sum(self.final_score_history[eval_uid]) / len(self.final_score_history[eval_uid])
                     )
                     tplr.logger.debug(
-                        f"Final Moving Average Score : {self.final_moving_avg_scores[eval_uid]}"
+                        f"Updated Final Moving Average Score for UID {eval_uid}: {self.final_moving_avg_scores[eval_uid]}"
                     )
 
                     self.evaluated_uids.add(eval_uid)


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->

### Summary
This PR updates the scoring mechanism for the validator by replacing the exponential moving average (EMA) for the _final moving average score_ with a true sliding window average. The goal is to ensure that early high scores do not provide long-term unfair advantages and that more recent evaluations better reflect a peer’s current performance.

### Changes
- **Final Moving Average Calculation:**  
  - Removed the EMA-based update for the final moving average score in the validator.
  - Replaced it with a sliding window mechanism that collects the last N final scores. The final moving average is computed as the simple average over these scores.
- **Hyperparameter Update:**  
  - Added (if not already present) the `moving_average_window` hyperparameter in `hparams.json`.  
  - In this configuration, its value is set to **5**, meaning that only the last 5 final scores are used to compute the average.
- **Rationale:**  
  - This change prevents early participants from "coasting" with an indefinitely high score due to the inertia of EMA, allowing the scores to better reflect more recent performance.
  - A sliding window offers faster adaptation to recent trends in performance, leveling the playing field for new participants.


## Related Issue(s)

- Closes #118 

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.