### PR TITLE
[draft] timestamp calculation

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -189,6 +189,11 @@ class Validator:
         self.current_block = self.subtensor.block
         self.current_window = int(self.current_block / self.hparams.blocks_per_window)
         self.start_window = self.current_window  # Record the start window
+        self.start_window_start_time = tplr.neurons.get_window_start_time(
+            subtensor=self.subtensor,
+            window=self.start_window,
+            blocks_per_window=self.hparams.blocks_per_window,
+        )
         self.global_step = 0  # Initialize global_step to zero
         self.comms.current_window = self.current_window
         self.sync_window = self.current_window
@@ -448,9 +453,12 @@ class Validator:
                         tplr.logger.error(
                             "Exceeded maximum retries for timestamp query."
                         )
-                        time_min += timedelta(
-                            seconds=12 * self.hparams.blocks_per_window
+                        time_min = self.start_window_start_time + timedelta(
+                            seconds=12
+                            * self.hparams.blocks_per_window
+                            * (self.sync_window - self.start_window)
                         )
+                        incremented_time_min = True
                         break
 
                     delay = min(delay * 2, max_delay)


### PR DESCRIPTION
- Sets `incremented_time_min` to `True` when incremented
- Handles the edge case where the validator skips a window, where simply
  incrementing `time_min` by a window's length would give the wrong
  time by at least one window's length. Instead, we calculate a new
  `time_min` based on the start window's start time and the number of
  windows since then.
