### PR TITLE
(hparams) Change weight decay to 0

### DIFF
--- a/hparams.json
+++ b/hparams.json
@@ -23,7 +23,7 @@
     "num_key_value_heads": 8,
     "activation_function": "swiGLU",
     "max_position_embeddings": 2048,
-    "weight_decay": 0.1,
+    "weight_decay": 0.0,
     "warmup_steps": 250,
     "alpha_f": 0.1,
     "t_max": 5000,


### PR DESCRIPTION
`DeMo` 1B is running with 0 in weight decay so we will try it in a run
to see the difference.
