### PR TITLE
fix: remove weights_only from torch.load to support debug pt files

### DIFF
--- a/src/tplr/comms.py
+++ b/src/tplr/comms.py
@@ -442,8 +442,8 @@ class Comms(ChainManager):
                         loaded_data = torch.load(
                             temp_file_path,
                             map_location=self.config.device,
-                            #weights_only=True,
                         )
+                        
                     return loaded_data
 
                 except asyncio.TimeoutError:

--- a/src/tplr/comms.py
+++ b/src/tplr/comms.py
@@ -442,7 +442,7 @@ class Comms(ChainManager):
                         loaded_data = torch.load(
                             temp_file_path,
                             map_location=self.config.device,
-                            weights_only=True,
+                            #weights_only=True,
                         )
                     return loaded_data
 

--- a/src/tplr/comms.py
+++ b/src/tplr/comms.py
@@ -443,7 +443,6 @@ class Comms(ChainManager):
                             temp_file_path,
                             map_location=self.config.device,
                         )
-                        
                     return loaded_data
 
                 except asyncio.TimeoutError:


### PR DESCRIPTION
## Summary

Removes `weights_only=True` from `torch.load()` to fix loading errors

## Why

Debug files from validators debug-751175-1-v0.2.62.pt fail to load

## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->


## Related Issue(s)

Fixes: debug files failing to load during `s3_get_object()` when `weights_only=True`.

## Type of Change
<!--
This PR removes the `weights_only=True` argument from `torch.load()` inside `comms.py`.  
This fixes the following error when attempting to load debug
-->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.