### PR TITLE
feat: toy model and vali e2e test

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,58 +1,31 @@
-require('dotenv').config({ path: '.env' });
-const RANDOM_SUFFIX = require('child_process').execSync("cat /dev/urandom | tr -dc 'a-z0-9' | fold -w 4 | head -n 1").toString().trim();
-const PROJECT_NAME = `test_${RANDOM_SUFFIX}`;
+const NUM_MINERS = process.env.NUM_MINERS || 5;
+const PROJECT_NAME = `templar-test`;
+const LOCAL_FLAG = process.env.LOCAL === 'true' ? ' --local' : '';
+
+// Create array of miner configurations
+const minerConfigs = [...Array(Number(NUM_MINERS))].map((_, index) => ({
+    name: `TM${index}`,
+    script: "neurons/miner.py",
+    interpreter: "python3",
+    env: {
+        ...process.env,
+        PROJECT_NAME: PROJECT_NAME
+    },
+    args: `--wallet.name miner --wallet.hotkey M${index} --device cpu --subtensor.network local --netuid 2 --use_wandb --project "${PROJECT_NAME}"${LOCAL_FLAG}`
+}));
 
 module.exports = {
     apps: [
-        // {
-        //     name: "TA1",
-        //     script: "neurons/aggregator.py",
-        //     interpreter: "python3",
-        //     env: {
-        //         ...process.env,
-        //         PROJECT_NAME: PROJECT_NAME
-        //     },
-        //     args: `--wallet.name validator --wallet.hotkey default --device cuda:0 --subtensor.network local --netuid 2 --use_wandb --project "${PROJECT_NAME}"`
-        // },
-        // {
-        //     name: "TV1",
-        //     script: "neurons/validator.py",
-        //     interpreter: "python3",
-        //     env: {
-        //         ...process.env,
-        //         PROJECT_NAME: PROJECT_NAME
-        //     },
-        //     args: `--wallet.name validator --wallet.hotkey default --device cuda:1 --subtensor.network local --netuid 2 --use_wandb --project "${PROJECT_NAME}"`
-        // },
-        // {
-        //     name: "TM1",
-        //     script: "neurons/miner.py",
-        //     interpreter: "python3",
-        //     env: {
-        //         ...process.env,
-        //         PROJECT_NAME: PROJECT_NAME
-        //     },
-        //     args: `--wallet.name miner1 --wallet.hotkey default --device cuda:2 --subtensor.network local --netuid 2 --use_wandb --project "${PROJECT_NAME}"`
-        // },
-        // {
-        //     name: "TM2",
-        //     script: "neurons/miner.py",
-        //     interpreter: "python3",
-        //     env: {
-        //         ...process.env,
-        //         PROJECT_NAME: PROJECT_NAME
-        //     },
-        //     args: `--wallet.name miner2 --wallet.hotkey default --device cuda:3 --subtensor.network local --netuid 2 --use_wandb --project "${PROJECT_NAME}"`
-        // },
+        ...minerConfigs,
         {
-            name: "TA1",
-            script: "neurons/aggregator.py",
+            name: "TV1",
+            script: "neurons/validator.py",
             interpreter: "python3",
             env: {
                 ...process.env,
                 PROJECT_NAME: PROJECT_NAME
             },
-            args: `--wallet.name templar --wallet.hotkey templar_validator --device cuda:4 --subtensor.network ws://159.69.219.238:11144 --netuid 3 --use_wandb --project templar`
-        },
+            args: `--wallet.name validator --wallet.hotkey default --device cpu --subtensor.network local --netuid 2 --use_wandb --project "${PROJECT_NAME}"${LOCAL_FLAG}`
+        }
     ]
 }

--- a/hparams-local-run.json
+++ b/hparams-local-run.json
@@ -1,0 +1,9 @@
+{
+    "pages_per_window": 1,
+    "hidden_size": 32,
+    "num_hidden_layers": 1,
+    "num_attention_heads": 4,
+    "intermediate_size": 128,
+    "num_key_value_heads": 4,
+    "max_position_embeddings": 128
+}

--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -82,6 +82,11 @@ class Miner:
             action="store_true",
             help="Test mode - use all peers without filtering",
         )
+        parser.add_argument(
+            "--local",
+            action="store_true",
+            help="Local run - use toy model, small enough for a laptop.",
+        )
         bt.subtensor.add_args(parser)
         bt.logging.add_args(parser)
         bt.wallet.add_args(parser)
@@ -98,7 +103,7 @@ class Miner:
 
         # Init config and load hparams
         self.config = Miner.config()
-        self.hparams = tplr.load_hparams()
+        self.hparams = tplr.load_hparams(use_local_run_hparams=self.config.local)
 
         # Init bittensor objects
         self.wallet = bt.wallet(config=self.config)

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -104,6 +104,11 @@ class Validator:
             action="store_true",
             help="Local run - use toy model, small enough for a laptop.",
         )
+        parser.add_argument(
+            "--log-to-private-wandb",
+            action="store_true",
+            help="Logs to the entity you are signed in to if true, else to the public 'tplr'.",
+        )
         bt.subtensor.add_args(parser)
         bt.logging.add_args(parser)
         bt.wallet.add_args(parser)

--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -99,6 +99,11 @@ class Validator:
             action="store_true",
             help="Test mode - use all peers without filtering",
         )
+        parser.add_argument(
+            "--local",
+            action="store_true",
+            help="Local run - use toy model, small enough for a laptop.",
+        )
         bt.subtensor.add_args(parser)
         bt.logging.add_args(parser)
         bt.wallet.add_args(parser)
@@ -115,7 +120,7 @@ class Validator:
 
         # Init config and load hparams
         self.config = Validator.config()
-        self.hparams = tplr.load_hparams()
+        self.hparams = tplr.load_hparams(use_local_run_hparams=self.config.local)
 
         # Init bittensor objects
         self.wallet = bt.wallet(config=self.config)

--- a/src/tplr/hparams.py
+++ b/src/tplr/hparams.py
@@ -104,7 +104,9 @@ def create_namespace(hparams: dict) -> SimpleNamespace:
     return hparams_ns
 
 
-def load_hparams(hparams_file: str = "hparams.json") -> SimpleNamespace:
+def load_hparams(
+    hparams_file: str = "hparams.json", use_local_run_hparams: bool = False
+) -> SimpleNamespace:
     """
     Load hyperparameters from a JSON file.
 
@@ -122,6 +124,15 @@ def load_hparams(hparams_file: str = "hparams.json") -> SimpleNamespace:
     try:
         with open(hparams_file, "r") as f:
             hparams = json.load(f)
+        if use_local_run_hparams:
+            with open("hparams-local-run.json", "r") as f:
+                hparams_local_run = json.load(f)
+            hparams.update(hparams_local_run)
+            logger.info(
+                f"Using these special hparams for a local run: {hparams_local_run}"
+            )
+        else:
+            logger.info("Using hparams for a normal run (not local)")
         return create_namespace(hparams)
     except FileNotFoundError:
         logger.warning(f"No {hparams_file} found, using default hyperparameters")

--- a/src/tplr/wandb.py
+++ b/src/tplr/wandb.py
@@ -45,7 +45,7 @@ def initialize_wandb(
     # Initialize WandB with version as a tag
     run = wandb.init(
         project=config.project,
-        entity="tplr",
+        entity=None if config.log_to_private_wandb else "tplr",
         id=run_id,
         resume="must" if run_id else "never",
         name=f"{run_prefix}{uid}",

--- a/tests/e2e/test_validator.py
+++ b/tests/e2e/test_validator.py
@@ -1,0 +1,69 @@
+import asyncio
+
+import pytest
+
+import tplr
+from neurons.validator import Validator
+
+
+@pytest.fixture
+def mock_args(mocker):
+    """Setup mock command line arguments"""
+    args = [
+        "validator.py",
+        "--netuid",
+        "2",
+        "--local",  # Use local/small model
+        "--wallet.name",
+        "validator",
+        "--wallet.hotkey",
+        "default",
+        "--subtensor.network",
+        "local",  # Local subtensor
+        "--device",
+        "cpu",
+        "--log-to-private-wandb",
+        "--project",
+        "templar-test",
+    ]
+    mocker.patch("sys.argv", args)
+
+
+async def test_validator(mocker, mock_args):
+    """Test that the validator properly updates its peer list"""
+    tplr.__version__ = "0.0.0test"
+    # Setup mocks
+    mock_update_peers = mocker.patch("tplr.neurons.update_peers", autospec=True)
+    mock_update_peers_with_buckets = mocker.patch(
+        "tplr.comms.Comms.update_peers_with_buckets", autospec=True
+    )
+
+    # Create and run validator
+    tplr.logger.info("Creating validator")
+    validator = Validator()
+    tplr.logger.info("Created validator")
+    initial_window = validator.current_window
+
+    # Start validator as a task
+    tplr.logger.info("Running validator")
+    validator_task = asyncio.create_task(validator.run())
+
+    # Wait for next window
+    while (
+        validator.current_window
+        < initial_window + 2 + validator.hparams.validator_offset
+    ):
+        await asyncio.sleep(1)
+
+    # Stop the validator
+    validator_task.cancel()
+    try:
+        await validator_task
+    except asyncio.CancelledError:
+        pass
+
+    tplr.logger.info("Stopped validator")
+
+    # Assert that both peer update methods were called
+    mock_update_peers.assert_called_once()
+    mock_update_peers_with_buckets.assert_called_once()

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -1,0 +1,21 @@
+from transformers import LlamaForCausalLM
+
+import tplr
+
+# Maximum allowed number of parameters (number of parameters using the local
+MAX_PARAMS = 2_064_480
+
+
+def test_toy_model_creation():
+    """Test that we can create a minimal working model configuration"""
+    # Load default hparams
+    hparams = tplr.load_hparams(use_local_run_hparams=True)
+
+    # Create the model
+    model = LlamaForCausalLM(hparams.model_config)
+
+    # Count total parameters and assert it's under 3M
+    total_params = sum(p.numel() for p in model.parameters())
+    assert total_params <= MAX_PARAMS, (
+        f"Model has {total_params:,} parameters, which exceeds the {MAX_PARAMS:,} limit"
+    )


### PR DESCRIPTION
This PR mainly does two things:
- enabling running the validator or the miner with a toy model, so small it
runs on a laptop
- introduces an end-to-end test for the validator

Unfortunately the e2e test is failing because `self.comms.incative_peers` isn't
defined, which it should be. Couldn't figure it out. Also the test is very
minimal but it could be a starting point if we want to start e2e-testing.
