### PR TITLE
feat: check if start window is already there for this version

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -365,16 +365,24 @@ class Validator:
 
             if existing_start_window is not None:
                 self.start_window = existing_start_window
-                tplr.logger.info(f"Highest staked validator found existing start_window: {self.start_window}")
+                tplr.logger.info(
+                    f"Highest staked validator found existing start_window: {self.start_window}"
+                )
             else:
                 # No existing start window, so post new start window to R2
                 await self.comms.post_start_window(self.start_window)
-                tplr.logger.info(f"This validator is the highest staked. Posted start_window: {self.start_window}")
+                tplr.logger.info(
+                    f"This validator is the highest staked. Posted start_window: {self.start_window}"
+                )
         else:
-            tplr.logger.info("This validator is not the highest staked. Waiting to fetch start_window.")
+            tplr.logger.info(
+                "This validator is not the highest staked. Waiting to fetch start_window."
+            )
             self.start_window = await self.comms.get_start_window()
             self.global_step = self.current_window - self.start_window
-            tplr.logger.info(f"Using start_window: {self.start_window}, global_step: {self.global_step}")
+            tplr.logger.info(
+                f"Using start_window: {self.start_window}, global_step: {self.global_step}"
+            )
 
         # Proceed to load checkpoint
         (

--- a/src/tplr/comms.py
+++ b/src/tplr/comms.py
@@ -1535,7 +1535,7 @@ class Comms(ChainManager):
                     tplr.logger.info(
                         "I am the highest staked validator and no start_window has been posted; breaking out."
                     )
-                    return 0  # TODO: adjust default value if needed
+                    return
 
                 tplr.logger.warning(
                     "start_window.json not found or empty. Retrying in 10 seconds"

--- a/src/tplr/comms.py
+++ b/src/tplr/comms.py
@@ -1548,7 +1548,6 @@ class Comms(ChainManager):
                     tplr.logger.info(
                         "I am the highest staked validator; breaking out on exception."
                     )
-                    return 0  # TODO: adjust default value if needed
                 await asyncio.sleep(10)
 
     async def save_checkpoint(

--- a/src/tplr/comms.py
+++ b/src/tplr/comms.py
@@ -1529,6 +1529,14 @@ class Comms(ChainManager):
                     tplr.logger.info(f"Fetched start_window: {start_window}")
                     return start_window
 
+                # Here, if no data and we are the highest staked validator,
+                # break out immediately rather than sleeping.
+                if self.uid == validator_uid:
+                    tplr.logger.info(
+                        "I am the highest staked validator and no start_window has been posted; breaking out."
+                    )
+                    return 0  # TODO: adjust default value if needed
+
                 tplr.logger.warning(
                     "start_window.json not found or empty. Retrying in 10 seconds"
                 )
@@ -1536,6 +1544,11 @@ class Comms(ChainManager):
 
             except Exception as e:
                 tplr.logger.error(f"Error fetching start_window: {e}")
+                if self.uid == validator_uid:
+                    tplr.logger.info(
+                        "I am the highest staked validator; breaking out on exception."
+                    )
+                    return 0  # TODO: adjust default value if needed
                 await asyncio.sleep(10)
 
     async def save_checkpoint(


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->

This PR addresses an issue in `neurons/validator.py` where the highest staked validator would always post a new start window on restart even if one already exists. By first checking for an existing start window via `comms.get_start_window()`, the validator now uses the existing start window if available instead of overwriting it.

### Changes

- **Validator Logic Update:**
  - Modified the code block in `neurons/validator.py` where, if the current validator is the highest staked, it now attempts to fetch an existing start window.
  - If an existing start window is found, the validator reuses it. Otherwise, it posts a new start window via `comms.post_start_window()`.
- **Logging Enhancements:**
  - Added informative logs to indicate whether an existing start window was found or a new one was posted.
- **Behavior for Non-Highest Staked Validators:**
  - They continue waiting and fetching the start window as usual.

### Rationale

When the highest staked validator is restarted, posting a new start window creates inconsistencies in the network's synchronization. This change ensures stability by preserving the originally posted start window across restarts.


---

This PR should resolve the issue where the start window was unnecessarily reset on each restart, thereby supporting a more robust and consistent synchronization within the network.

## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.