### PR TITLE
chore: added a new field(normalised_binary_moving_averages) to load/save state logic

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -2244,6 +2244,7 @@ class Validator:
                 final_moving_avg_scores=self.final_moving_avg_scores,
                 binary_moving_averages=self.binary_moving_averages,
                 weights=self.weights,
+                normalised_binary_moving_averages=self.normalised_binary_moving_averages,
             )
         except Exception as e:
             tplr.logger.warning(f"Failed to save validator state: {e}")
@@ -2262,6 +2263,7 @@ class Validator:
             self.final_moving_avg_scores = state["final_moving_avg_scores"]
             self.binary_moving_averages = state["binary_moving_averages"]
             self.weights = state["weights"]
+            self.normalised_binary_moving_averages = state["normalised_binary_moving_averages"]
             tplr.logger.info(
                 f"Loaded state from global state {state.global_state}: {state}"
             )


### PR DESCRIPTION
Ensures the field is persisted and restored correctly across sessions.