### PR TITLE
(hparams) Lower time window delta seconds to 10

### DIFF
--- a/hparams.json
+++ b/hparams.json
@@ -43,7 +43,7 @@
     "catch_up_batch_size": 5,
     "catch_up_timeout": 300,
     "uids_per_window": 2,
-    "time_window_delta_seconds": 25,
+    "time_window_delta_seconds": 10,
     "reset_inactivity_windows": 25,
     "max_gradient_score": 0.05,
     "sync_max_steps_behind": 3


### PR DESCRIPTION
The reason being is that with some recent changes of gradient size and
multi part upload the PUT is on average much quicker than it used to be.

## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
-->


## Related Issue(s)

- Closes #[issue number]

## Type of Change
<!--
Please check the relevant options:
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please describe):

## Breaking Change

If this PR introduces a breaking change, please provide a detailed description of the impact and the migration path for existing applications.

## Checklist

<!--
Please ensure the following tasks are completed before requesting a review:
-->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have run `cargo fmt` and `cargo clippy` to ensure my code is formatted and linted correctly
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots (if applicable)

Please include any relevant screenshots or GIFs that demonstrate the changes made.

## Additional Notes

Please provide any additional information or context that may be helpful for reviewers.