### PR TITLE
(miner) adding tokens_per_sec back to metrics logger

### DIFF
--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -688,6 +688,7 @@ class Miner:
                     "gather_time": gather_time,
                     "put_time": put_completion_time,
                     "model_update_time": model_update_time,
+                    "tokens_per_sec": tokens_per_sec,
                 },
             )
             tplr.logger.info("Finished metrics logging call for miner")


### PR DESCRIPTION
## Description

fixing a regression matter, whereby this metric is still missing from the miners metrics logs.