### PR TITLE
(comms) Make sure we fetch correct peers

### DIFF
--- a/src/tplr/comms.py
+++ b/src/tplr/comms.py
@@ -1528,6 +1528,9 @@ class Comms(ChainManager):
                     sorted_windows = sorted(window_to_keys, reverse=True)
                     selected_window = sorted_windows[1]  # Second most recent
                     tplr.logger.info(f"Selected previous window {selected_window}")
+                elif fetch_previous and len(window_to_keys) <= 1:
+                    tplr.logger.info(f"Found no previous window {selected_window}")
+                    return None
                 else:
                     selected_window = max(window_to_keys)  # Most recent
                     tplr.logger.info(f"Selected most recent window {selected_window}")


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
  Focus on the "what" and "why" rather than the "how".
-->

Before, in the beginning of the run when we only had one peer list for a
window, we ended up applying the latest one becuase of the faulty logic.
This make sure we return `None` if we try to fetch previous peer list
and don't have more than one peer list available on the bucket.


## Related Issue(s)
<!-- Link any related issues using the syntax: -->
- Closes #[issue number]

## Type of Change
<!-- Check the relevant option(s): -->
- [ ] Feature (adding new functionality)
- [x] Fix (resolving a bug or issue)
- [ ] Docs (documentation updates)
- [ ] Refactor (code changes that don't affect functionality)
- [ ] Maintenance (dependency updates or other maintenance)
- [ ] Tests (adding or improving tests)
- [ ] Breaking change (fix or feature with incompatible API changes)
- [ ] Other: _____

## Branch Naming
<!-- Confirm your branch follows the naming convention: <kind>/<description> -->
- [x] My branch follows the project's naming convention (e.g., feature/add-new-capability)

## Commit Messages
<!-- Ensure your commits follow the project guidelines -->
- [x] My commits are small, atomic, and have proper commit messages
- [x] Commit messages are in imperative mood with a capitalized summary under 50 chars

## Code Quality
<!-- Check all that apply: -->
- [x] I've performed a self-review of my code
- [ ] I've added appropriate docstrings following the project's conventions
- [x] I've added proper logging where necessary (without trailing periods)
- [x] I've applied linting and formatting with Ruff
- [x] My code generates no new warnings

## Testing
<!-- Check all that apply: -->
- [ ] I've added tests for new functionality or bug fixes
- [ ] All tests pass locally with my changes
- [ ] Test coverage has not decreased

## Documentation
<!-- Check if relevant: -->
- [ ] I've updated documentation to reflect my changes
- [ ] I've updated comments in hard-to-understand areas
