### PR TITLE
(evaluator) fix get_latest_checkpoint to load from version

### DIFF
--- a/scripts/evaluator.py
+++ b/scripts/evaluator.py
@@ -172,6 +172,10 @@ class Evaluator:
         self.hparams = tplr.load_hparams()
         self.wallet = bt.wallet(config=self.config)
 
+        self.version = getattr(
+            self.hparams, "checkpoint_init_version", tplr.__version__
+        )
+
         # Mock for the comms class
         self.uid = 1
 
@@ -229,7 +233,7 @@ class Evaluator:
             - checkpoint_window (int): Window number of checkpoint
             - global_step (int): Global training step
         """
-        result = await self.comms.get_latest_checkpoint()  # type: ignore
+        result = await self.comms.get_latest_checkpoint(version=self.version)
         if not result:
             tplr.logger.error(
                 f"No valid checkpoints found. Check bucket: {getattr(self.comms, 'bucket_name', 'unknown')}, "

--- a/scripts/evaluator.py
+++ b/scripts/evaluator.py
@@ -172,9 +172,7 @@ class Evaluator:
         self.hparams = tplr.load_hparams()
         self.wallet = bt.wallet(config=self.config)
 
-        self.version = getattr(
-            self.hparams, "checkpoint_init_version", tplr.__version__
-        )
+        self.version = tplr.__version__
 
         # Mock for the comms class
         self.uid = 1

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -128,16 +128,16 @@ async def test_evaluator_loads_new_checkpoints(evaluator):
 
     evaluator.model.load_state_dict.assert_called_once()
 
-    assert (
-        evaluator.momentum == momentum_data
-    ), "Should load the exact momentum data from checkpoint"
+    assert evaluator.momentum == momentum_data, (
+        "Should load the exact momentum data from checkpoint"
+    )
 
     evaluator.model.to.assert_called_once_with(evaluator.config.device)
 
     assert loaded_model_state is not None, "Model state dict should be loaded"
-    assert len(loaded_model_state) == len(
-        model_state_dict
-    ), "Model state dict should have same number of keys"
+    assert len(loaded_model_state) == len(model_state_dict), (
+        "Model state dict should have same number of keys"
+    )
     for key in model_state_dict:
         assert key in loaded_model_state, f"Key {key} should be in loaded state dict"
 

--- a/tests/test_evaluator.py
+++ b/tests/test_evaluator.py
@@ -6,11 +6,12 @@
 4. Updating tracking state correctly
 """
 
-import sys
 import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 import torch
-from unittest.mock import MagicMock, patch, AsyncMock
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -42,6 +43,7 @@ def setup_evaluator_with_mocks():
         evaluator.model = MagicMock()
         evaluator.metrics_logger = MagicMock()
         evaluator.comms = MagicMock()
+        evaluator.version = "test_version"
 
         yield evaluator
 
@@ -67,11 +69,13 @@ async def test_evaluator_skips_old_checkpoints(evaluator):
         "momentum": {"layer.weight": torch.zeros(10, 10)},
     }
 
-    evaluator.comms.get_latest_checkpoint = AsyncMock(
-        return_value=(old_checkpoint_data, None)
-    )
+    mock_get_latest = AsyncMock(return_value=(old_checkpoint_data, None))
+    evaluator.comms.get_latest_checkpoint = mock_get_latest
 
     success, data, window, step = await evaluator.load_latest_model()
+
+    # Verify that get_latest_checkpoint was called with the version parameter
+    mock_get_latest.assert_called_once_with(version=evaluator.version)
 
     assert not success, "Should not load when checkpoint window equals last_eval_window"
     assert window == 100, "Should return correct window number"
@@ -110,11 +114,13 @@ async def test_evaluator_loads_new_checkpoints(evaluator):
         return None
 
     evaluator.model.load_state_dict.side_effect = capture_model_load
-    evaluator.comms.get_latest_checkpoint = AsyncMock(
-        return_value=(new_checkpoint_data, None)
-    )
+    mock_get_latest = AsyncMock(return_value=(new_checkpoint_data, None))
+    evaluator.comms.get_latest_checkpoint = mock_get_latest
 
     success, data, window, step = await evaluator.load_latest_model()
+
+    # Verify that get_latest_checkpoint was called with the version parameter
+    mock_get_latest.assert_called_once_with(version=evaluator.version)
 
     assert success, "Should load when checkpoint window > last_eval_window"
     assert window == 110, "Should return correct window number"
@@ -122,16 +128,16 @@ async def test_evaluator_loads_new_checkpoints(evaluator):
 
     evaluator.model.load_state_dict.assert_called_once()
 
-    assert evaluator.momentum == momentum_data, (
-        "Should load the exact momentum data from checkpoint"
-    )
+    assert (
+        evaluator.momentum == momentum_data
+    ), "Should load the exact momentum data from checkpoint"
 
     evaluator.model.to.assert_called_once_with(evaluator.config.device)
 
     assert loaded_model_state is not None, "Model state dict should be loaded"
-    assert len(loaded_model_state) == len(model_state_dict), (
-        "Model state dict should have same number of keys"
-    )
+    assert len(loaded_model_state) == len(
+        model_state_dict
+    ), "Model state dict should have same number of keys"
     for key in model_state_dict:
         assert key in loaded_model_state, f"Key {key} should be in loaded state dict"
 


### PR DESCRIPTION
## Description
fixing a regression issue when comms got updated. Evaluator wasn't.

![image](https://github.com/user-attachments/assets/11947d16-dda5-41a9-adfe-4b8c5759c131)
