### PR TITLE
(validator) init OpenSkill before state restore

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -193,6 +193,11 @@ class Validator:
             milestones=[250],
         )
 
+        self.openskill_model = PlackettLuce(
+            beta=self.hparams.openskill_beta, tau=self.hparams.openskill_tau
+        )
+        self.openskill_ratings = {}  # Dictionary to store peer ratings
+
         self.bootstrap_version = getattr(self.hparams, "checkpoint_init_version", None)
         tplr.logger.info(
             f"[Miner] code_version={tplr.__version__} "
@@ -293,10 +298,6 @@ class Validator:
         # Initialize peer related attributes
         self.next_peers: tplr.comms.PeerArray | None = None
         self.peers_update_window = -1
-        self.openskill_model = PlackettLuce(
-            beta=self.hparams.openskill_beta, tau=self.hparams.openskill_tau
-        )
-        self.openskill_ratings = {}  # Dictionary to store peer ratings
 
     def reset_peer(self, inactive_since: int, uid: int) -> bool:
         if self.current_window - inactive_since > self.hparams.reset_inactivity_windows:


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
  Focus on the "what" and "why" rather than the "how".
-->

Ensure the OpenSkill model is initialized before calling
`self.load_state` so that the state can be properly restored after a
crash. Otherwise we get:

```bash
Failed to restore OpenSkill ratings: 'Validator' object has no attribute
'openskill_model'
```

## Related Issue(s)
<!-- Link any related issues using the syntax: -->
None

## Type of Change
<!-- Check the relevant option(s): -->
- [ ] Feature (adding new functionality)
- [x] Fix (resolving a bug or issue)
- [ ] Docs (documentation updates)
- [ ] Refactor (code changes that don't affect functionality)
- [ ] Maintenance (dependency updates or other maintenance)
- [ ] Tests (adding or improving tests)
- [ ] Breaking change (fix or feature with incompatible API changes)
- [ ] Other: _____

## Branch Naming
<!-- Confirm your branch follows the naming convention: <kind>/<description> -->
- [x] My branch follows the project's naming convention (e.g., feature/add-new-capability)

## Commit Messages
<!-- Ensure your commits follow the project guidelines -->
- [x] My commits are small, atomic, and have proper commit messages
- [x] Commit messages are in imperative mood with a capitalized summary under 50 chars

## Code Quality
<!-- Check all that apply: -->
- [x] I've performed a self-review of my code
- [ ] I've added appropriate docstrings following the project's conventions
- [ ] I've added proper logging where necessary (without trailing periods)
- [ ] I've applied linting and formatting with Ruff
- [ ] My code generates no new warnings

## Testing
<!-- Check all that apply: -->
- [ ] I've added tests for new functionality or bug fixes
- [ ] All tests pass locally with my changes
- [ ] Test coverage has not decreased

## Documentation
<!-- Check if relevant: -->
- [ ] I've updated documentation to reflect my changes
- [ ] I've updated comments in hard-to-understand areas

## If this is a breaking change
<!--
  If applicable, describe the impact and migration path for existing applications.
  Otherwise, you can remove this section.
-->

## Screenshots/Examples
<!-- If applicable, add screenshots or examples to help explain your changes. -->

## Additional Notes
<!-- Add any other context about the PR here. -->
