### PR TITLE
(validator) await first eval uid data

### DIFF
--- a/neurons/validator.py
+++ b/neurons/validator.py
@@ -1208,9 +1208,7 @@ class Validator:
                     sync_window=self.sync_window,
                     current_window=self.current_window,
                 )
-                next_uid_dataloader_task = asyncio.create_task(
-                    self.preload_dataloader(seed=next_uid)
-                )
+                next_uid_dataloader_task = await self.preload_dataloader(seed=next_uid)
 
             # Process each UID with sliding window loading
             while next_uid is not None:


### PR DESCRIPTION
## Description
<!--
  Please provide a brief description of the changes introduced by this pull request.
  Focus on the "what" and "why" rather than the "how".
-->

We need to ensure we await this before pre-loading any new data. This
will make it a bit slower with evaluation but otherwise we get errors:

```bash
Attempt 1/3 failed for loader for UID: 2: 'NoneType' object has no
attribute '_log_stats'
```

## Related Issue(s)
<!-- Link any related issues using the syntax: -->
- Closes #[issue number]

## Type of Change
<!-- Check the relevant option(s): -->
- [ ] Feature (adding new functionality)
- [x] Fix (resolving a bug or issue)
- [ ] Docs (documentation updates)
- [ ] Refactor (code changes that don't affect functionality)
- [ ] Maintenance (dependency updates or other maintenance)
- [ ] Tests (adding or improving tests)
- [ ] Breaking change (fix or feature with incompatible API changes)
- [ ] Other: _____

## Branch Naming
<!-- Confirm your branch follows the naming convention: <kind>/<description> -->
- [x] My branch follows the project's naming convention (e.g., feature/add-new-capability)

## Commit Messages
<!-- Ensure your commits follow the project guidelines -->
- [x] My commits are small, atomic, and have proper commit messages
- [x] Commit messages are in imperative mood with a capitalized summary under 50 chars

## Code Quality
<!-- Check all that apply: -->
- [x] I've performed a self-review of my code
- [ ] I've added appropriate docstrings following the project's conventions
- [ ] I've added proper logging where necessary (without trailing periods)
- [ ] I've applied linting and formatting with Ruff
- [ ] My code generates no new warnings

## Testing
<!-- Check all that apply: -->
- [ ] I've added tests for new functionality or bug fixes
- [ ] All tests pass locally with my changes
- [ ] Test coverage has not decreased

## Documentation
<!-- Check if relevant: -->
- [ ] I've updated documentation to reflect my changes
- [ ] I've updated comments in hard-to-understand areas
