### PR TITLE
(evaluator-local) for local checkpoints

### DIFF
--- a/docs/evaluator-local.md
+++ b/docs/evaluator-local.md
@@ -1,0 +1,297 @@
+# Local Model Evaluator
+
+The Local Model Evaluator (`scripts/evaluator-local.py`) is a utility script that allows you to evaluate model checkpoints offline without connecting to the Bittensor network or Templar chain. This is useful for testing checkpoints locally, benchmarking models during development, or validating saved checkpoints before using them in production (through model_converter).
+
+## Overview
+
+Unlike the main evaluator script which pulls checkpoints from the network, this local evaluator:
+
+- Accepts checkpoint files directly from your local filesystem
+- Runs standardized benchmark tasks using the `lm-eval` library
+- Provides immediate feedback on model performance
+- Requires no network connection or chain registration
+
+## Prerequisites
+
+Before using the local evaluator, ensure you have:
+
+1. A valid model checkpoint file (`.pt` format)
+2. The `lm-eval` library installed: `pip install lm-eval`
+3. CUDA-enabled GPU (optional but recommended)
+4. Sufficient disk space for temporary model files
+
+## Installation
+
+The evaluator is part of the Templar repository. No additional installation is required beyond the standard Templar setup:
+
+```bash
+git clone <templar-repo>
+cd templar
+uv pip install -e ".[dev]"
+```
+
+## Usage
+
+### Basic Usage
+
+Evaluate a checkpoint using the default tasks:
+
+```bash
+python scripts/evaluator-local.py --checkpoint_path path/to/checkpoint.pt
+```
+
+### Custom Tasks
+
+Specify which benchmark tasks to run:
+
+```bash
+python scripts/evaluator-local.py \
+    --checkpoint_path checkpoint.pt \
+    --tasks arc_easy,winogrande,piqa
+```
+
+### Command Line Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--checkpoint_path` | Required | Path to the model checkpoint file |
+| `--device` | cuda | Device to use for evaluation (cuda/cpu) |
+| `--tasks` | arc_challenge,arc_easy,openbookqa,winogrande,piqa,hellaswag | Comma-separated list of evaluation tasks |
+| `--batch_size` | 8 | Evaluation batch size |
+| `--limit` | 1.0 | Fraction of dataset to evaluate (0.0-1.0) |
+| `--num_fewshot` | 0 | Number of few-shot examples |
+| `--output_dir` | evaluation_results | Directory to save results |
+| `--cleanup` | False | Clean up model files after evaluation |
+
+### Available Tasks
+
+The evaluator supports all tasks available in `lm-eval`. Common options include:
+
+- `arc_challenge`: AI2 Reasoning Challenge (challenge set)
+- `arc_easy`: AI2 Reasoning Challenge (easy set)
+- `openbookqa`: Open Book Question Answering
+- `winogrande`: Commonsense reasoning
+- `piqa`: Physical Interaction QA
+- `hellaswag`: Commonsense natural language inference
+- `truthfulqa_mc`: TruthfulQA multiple choice
+- `mmlu`: Massive Multitask Language Understanding
+
+## Step-by-Step Example
+
+### 1. Download or Prepare a Checkpoint
+
+First, obtain a checkpoint file. You can either:
+
+- Download from cloud storage:
+
+```bash
+rclone copy templar-validator:/80f15715bb0b882c9e967c13e677ed7d/checkpoint-792063-1-v0.2.81.pt ./checkpoints/
+```
+
+- Or copy from a local validator:
+
+```bash
+cp /path/to/validator/checkpoint.pt ./checkpoints/
+```
+
+### 2. Run the Evaluation
+
+Execute the evaluator with your desired configuration:
+
+```bash
+python scripts/evaluator-local.py \
+    --checkpoint_path ./checkpoints/checkpoint-792063-1-v0.2.81.pt \
+    --tasks arc_easy \
+    --device cuda
+```
+
+### 3. Monitor Progress
+
+The script will display progress as it:
+
+1. Loads the checkpoint
+2. Saves the model in HuggingFace format
+3. Runs the lm-eval benchmark
+4. Processes results
+
+### 4. Review Results
+
+After completion, you'll see output like:
+
+```text
+hf (pretrained=models/eval,tokenizer=models/eval), gen_kwargs: (None), limit: None, num_fewshot: None, batch_size: 8
+| Tasks  |Version|Filter|n-shot| Metric |   |Value |   |Stderr|
+|--------|------:|------|-----:|--------|---|-----:|---|-----:|
+|arc_easy|      1|none  |     0|acc     |↑  |0.5922|±  |0.0101|
+|        |       |none  |     0|acc_norm|↑  |0.5236|±  |0.0102|
+
+[13:48:23] Model files kept at: models/eval
+
+==================================================
+EVALUATION RESULTS
+==================================================
+
+Runtime: 48.35 seconds
+Config: {
+  "checkpoint_path": "../experimental/checkpoint-792063-1-v0.2.81.pt/checkpoint-792063-1-v0.2.81.pt",
+  "device": "cuda",
+  "tasks": "arc_easy",
+  "batch_size": 8,
+  "limit": 1.0,
+  "num_fewshot": 0,
+  "output_dir": "evaluation_results",
+  "cleanup": false
+}
+
+Task Scores:
+------------------------------
+arc_easy (acc_norm,none): 0.5236
+==================================================
+
+Results saved to evaluation_results/evaluation_summary.json
+```
+
+## Output Files
+
+The evaluator creates several output files:
+
+1. **Summary JSON**: `evaluation_results/evaluation_summary.json`
+   - Contains runtime, configuration, and aggregated scores
+   - Useful for programmatic analysis
+
+2. **Detailed Results**: `evaluation_results/models__eval/<timestamp>.json`
+   - Complete evaluation metrics from lm-eval
+   - Includes per-task breakdowns and statistics
+
+3. **Model Files**: `models/eval/` (unless `--cleanup` is used)
+   - Temporary HuggingFace format model files
+   - Can be reused for further evaluation
+
+## Advanced Usage
+
+### Quick Evaluation with Limited Samples
+
+For faster testing, evaluate on a subset of the data:
+
+```bash
+python scripts/evaluator-local.py \
+    --checkpoint_path checkpoint.pt \
+    --limit 0.1 \
+    --batch_size 16
+```
+
+### Multi-Task Evaluation
+
+Run multiple benchmarks in one command:
+
+```bash
+python scripts/evaluator-local.py \
+    --checkpoint_path checkpoint.pt \
+    --tasks arc_challenge,arc_easy,winogrande,piqa,hellaswag \
+    --output_dir comprehensive_eval
+```
+
+### Few-Shot Evaluation
+
+Test few-shot learning capabilities:
+
+```bash
+python scripts/evaluator-local.py \
+    --checkpoint_path checkpoint.pt \
+    --tasks arc_easy \
+    --num_fewshot 5
+```
+
+### CPU-Only Evaluation
+
+For systems without CUDA:
+
+```bash
+python scripts/evaluator-local.py \
+    --checkpoint_path checkpoint.pt \
+    --device cpu \
+    --batch_size 4
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Out of Memory Errors**
+   - Reduce `--batch_size`
+   - Use `--device cpu` for CPU evaluation
+   - Enable `--cleanup` to free resources
+
+2. **Missing Dependencies**
+
+   ```bash
+   pip install lm-eval transformers torch
+   ```
+
+3. **Checkpoint Loading Errors**
+   - Ensure checkpoint is compatible with the model architecture
+   - Check that the file path is correct and accessible
+
+4. **Slow Evaluation**
+   - Use `--limit 0.1` for quick tests
+   - Increase `--batch_size` if GPU memory allows
+   - Select fewer tasks
+
+### Error Messages
+
+- `FileNotFoundError: Checkpoint not found`: Verify the checkpoint path
+- `RuntimeError: Evaluation failed`: Check lm-eval installation and task names
+- `CUDA out of memory`: Reduce batch size or use CPU
+
+## Performance Tips
+
+1. **GPU Optimization**
+   - Use the largest batch size that fits in memory
+   - Ensure CUDA is properly configured
+
+2. **Quick Testing**
+   - Start with `--limit 0.1` to verify setup
+   - Run single tasks before comprehensive evaluation
+
+3. **Resource Management**
+   - Use `--cleanup` to remove temporary files
+   - Monitor GPU memory during evaluation
+
+## Integration with CI/CD
+
+The local evaluator can be integrated into automated workflows:
+
+```bash
+#!/bin/bash
+# CI evaluation script
+
+CHECKPOINT=$1
+THRESHOLD=0.5
+
+# Run evaluation
+python scripts/evaluator-local.py \
+    --checkpoint_path "$CHECKPOINT" \
+    --tasks arc_easy \
+    --output_dir ci_results \
+    --cleanup
+
+# Check results
+SCORE=$(jq '.results.arc_easy."acc_norm,none"' ci_results/evaluation_summary.json)
+if (( $(echo "$SCORE < $THRESHOLD" | bc -l) )); then
+    echo "Model performance below threshold!"
+    exit 1
+fi
+```
+
+## Best Practices
+
+1. **Version Control**: Track evaluation results alongside model versions
+2. **Consistent Settings**: Use the same batch size and device for comparable results
+3. **Regular Testing**: Evaluate checkpoints periodically during training
+4. **Documentation**: Record evaluation settings with results
+
+## See Also
+
+- [Evaluator Documentation](evaluator.md) - Network-based model evaluation
+- [Model Converter](model_converter.md) - Convert between checkpoint formats
+- [Miner Setup](miner.md) - Generate checkpoints for evaluation

--- a/scripts/evaluator-local.py
+++ b/scripts/evaluator-local.py
@@ -1,0 +1,221 @@
+"""Local Model Evaluator
+
+This script evaluates model checkpoints from local files using standardized benchmark tasks.
+Instead of pulling checkpoints from the Bittensor network, it accepts checkpoint paths as arguments.
+
+Usage:
+    python scripts/evaluator-local.py --checkpoint_path model_checkpoint.pt
+    python scripts/evaluator-local.py --checkpoint_path model_checkpoint.pt --tasks arc_challenge,winogrande
+"""
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import torch
+from transformers.models.llama import LlamaForCausalLM
+
+import tplr
+
+MODEL_PATH: str = "models/eval"
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Local evaluator script for model checkpoints"
+    )
+    parser.add_argument(
+        "--checkpoint_path",
+        type=str,
+        required=True,
+        help="Path to the model checkpoint file",
+    )
+    parser.add_argument(
+        "--device",
+        type=str,
+        default="cuda",
+        help="Device to use for evaluation",
+    )
+    parser.add_argument(
+        "--tasks",
+        type=str,
+        default="arc_challenge,arc_easy,openbookqa,winogrande,piqa,hellaswag",
+        help="Comma-separated list of tasks to evaluate",
+    )
+    parser.add_argument(
+        "--batch_size",
+        type=int,
+        default=8,
+        help="Evaluation batch size",
+    )
+    parser.add_argument(
+        "--limit",
+        type=float,
+        default=1.0,
+        help="Fraction of dataset to evaluate (0.0-1.0)",
+    )
+    parser.add_argument(
+        "--num_fewshot",
+        type=int,
+        default=0,
+        help="Number of few-shot examples",
+    )
+    parser.add_argument(
+        "--output_dir",
+        type=str,
+        default="evaluation_results",
+        help="Directory to save evaluation results",
+    )
+    parser.add_argument(
+        "--cleanup",
+        action="store_true",
+        help="Clean up model files after evaluation",
+    )
+
+    return parser.parse_args()
+
+
+def load_checkpoint(checkpoint_path: str, device: str) -> tuple[LlamaForCausalLM, dict]:
+    """Load model from checkpoint file."""
+    if not os.path.exists(checkpoint_path):
+        raise FileNotFoundError(f"Checkpoint not found: {checkpoint_path}")
+
+    tplr.logger.info(f"Loading checkpoint from {checkpoint_path}")
+
+    hparams = tplr.load_hparams()
+
+    model = LlamaForCausalLM(config=hparams.model_config)
+
+    checkpoint = torch.load(checkpoint_path, map_location=device)
+
+    if "model_state_dict" in checkpoint:
+        model_state = checkpoint["model_state_dict"]
+        metadata = {k: v for k, v in checkpoint.items() if k != "model_state_dict"}
+    else:
+        model_state = checkpoint
+        metadata = {}
+
+    model.load_state_dict(model_state)
+    model.to(device)  # type: ignore
+
+    tplr.logger.info("Model loaded successfully")
+    return model, metadata
+
+
+def run_evaluation(
+    model: LlamaForCausalLM,
+    hparams: SimpleNamespace,
+    args: argparse.Namespace,
+) -> dict:
+    """Run lm-eval benchmark and return results."""
+    os.makedirs(MODEL_PATH, exist_ok=True)
+    model.save_pretrained(MODEL_PATH)
+    hparams.tokenizer.save_pretrained(MODEL_PATH)
+
+    if args.limit < 1.0:
+        limit_arg = f"--limit {args.limit}"
+    else:
+        limit_arg = ""
+
+    if args.num_fewshot > 0:
+        fewshot_arg = f"--num_fewshot {args.num_fewshot}"
+    else:
+        fewshot_arg = ""
+
+    command = f"""
+    lm-eval --model hf \
+        --model_args pretrained={MODEL_PATH},tokenizer={MODEL_PATH} \
+        --tasks {args.tasks} \
+        --device {args.device} \
+        --batch_size {args.batch_size} \
+        --output_path {args.output_dir} \
+        {limit_arg} \
+        {fewshot_arg}
+    """.strip()
+
+    tplr.logger.info(f"Running benchmark: {command}")
+    start_time = time.time()
+    exit_code = os.system(command)
+    runtime = time.time() - start_time
+
+    if exit_code != 0:
+        raise RuntimeError(f"Evaluation failed with exit code {exit_code}")
+
+    results_dir = Path(args.output_dir) / "models__eval"
+    latest_file = max(results_dir.glob("*.json"), key=os.path.getctime)
+
+    with open(latest_file, "r") as f:
+        results = json.load(f)
+
+    if args.cleanup:
+        tplr.logger.info("Cleaning up model files")
+        shutil.rmtree(MODEL_PATH)
+        torch.cuda.empty_cache()
+    else:
+        tplr.logger.info(f"Model files kept at: {MODEL_PATH}")
+
+    return {
+        "benchmark_runtime": runtime,
+        "results": results["results"],
+        "config": args.__dict__,
+    }
+
+
+def print_results(results: dict) -> None:
+    """Print evaluation results in a readable format."""
+    print("\n" + "=" * 50)
+    print("EVALUATION RESULTS")
+    print("=" * 50)
+
+    print(f"\nRuntime: {results['benchmark_runtime']:.2f} seconds")
+    print(f"Config: {json.dumps(results['config'], indent=2)}")
+
+    print("\nTask Scores:")
+    print("-" * 30)
+
+    for task_name, task_results in results["results"].items():
+        # Priority order for metrics
+        metric_names = ["acc_norm,none", "acc,none"]
+
+        for metric_name in metric_names:
+            if (value := task_results.get(metric_name)) is not None:
+                print(f"{task_name} ({metric_name}): {value:.4f}")
+                break
+
+    print("=" * 50 + "\n")
+
+
+def main():
+    """Main entry point."""
+    args = parse_args()
+
+    try:
+        hparams = tplr.load_hparams()
+        model, metadata = load_checkpoint(args.checkpoint_path, args.device)
+
+        if metadata:
+            tplr.logger.info(f"Checkpoint metadata: {metadata}")
+
+        results = run_evaluation(model, hparams, args)
+
+        print_results(results)
+
+        output_file = Path(args.output_dir) / "evaluation_summary.json"
+        with open(output_file, "w") as f:
+            json.dump(results, f, indent=2)
+
+        tplr.logger.info(f"Results saved to {output_file}")
+
+    except Exception as e:
+        tplr.logger.error(f"Evaluation failed: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
this script allows you to eval local checkpoints. It's pretty much a trimmed down version of the https://github.com/tplr-ai/templar/blob/main/scripts/evaluator.py


```bash
python scripts/evaluator-local.py \
  --checkpoint_path checkpoint_model.pt \
  --tasks hellaswag \
  --device="cuda:1"
```

how to use for live checkpoints:

```bash
# first we download the checkpoint, or we produce it from the validator and save it locally
rclone copy templar-validator:/80f15715bb0b882c9e967c13e677ed7d/checkpoint-792063-1-v0.2.81.pt 
checkpoint-792063-1-v0.2.81.pt

# then we trigger the evaluator
python scripts/evaluator-local.py --checkpoint_path ../experimental/checkpoint-792063-1-v0.2.81.pt/checkpoint-792063-1-v0.2.81.pt --tasks arc_easy
```
