### PR TITLE
Check and move shift to the same device as dequantized

### DIFF
--- a/src/tplr/compress.py
+++ b/src/tplr/compress.py
@@ -316,6 +316,10 @@ class CompressDCT:
         # Convert quantized values back using lookup table
         dequantized = lookup[val.long()]
 
+        # Check and move shift to the same device as dequantized
+        if not shift.is_cuda or shift.device != dequantized.device:
+            shift = shift.to(dequantized.device)
+
         # Apply scale and shift to get back original distribution
         val = dequantized + shift
         val = val.to(orig_dtype)


### PR DESCRIPTION
## Description

Check and move shift to the same device as dequantized to avoid issues 

"Expected all tensors to be on the same device, but found at least two devices"

## Related Issue(s)
<!-- Link any related issues using the syntax: -->
- Closes #[issue number]

## Type of Change
<!-- Check the relevant option(s): -->
- [ ] Feature (adding new functionality)
- [x] Fix (resolving a bug or issue)
- [ ] Docs (documentation updates)
- [ ] Refactor (code changes that don't affect functionality)
- [ ] Maintenance (dependency updates or other maintenance)
- [ ] Tests (adding or improving tests)
- [ ] Breaking change (fix or feature with incompatible API changes)
- [ ] Other: _____

## Branch Naming
<!-- Confirm your branch follows the naming convention: <kind>/<description> -->
- [ ] My branch follows the project's naming convention (e.g., feature/add-new-capability)

## Commit Messages
<!-- Ensure your commits follow the project guidelines -->
- [x ] My commits are small, atomic, and have proper commit messages
- [x ] Commit messages are in imperative mood with a capitalized summary under 50 chars

## Code Quality
<!-- Check all that apply: -->
- [ ] I've performed a self-review of my code
- [ ] I've added appropriate docstrings following the project's conventions
- [ ] I've added proper logging where necessary (without trailing periods)
- [ ] I've applied linting and formatting with Ruff
- [ ] My code generates no new warnings

## Testing
<!-- Check all that apply: -->
- [ ] I've added tests for new functionality or bug fixes
- [ ] All tests pass locally with my changes
- [ ] Test coverage has not decreased

## Documentation
<!-- Check if relevant: -->
- [ ] I've updated documentation to reflect my changes
- [ ] I've updated comments in hard-to-understand areas

## Screenshots/Examples
<!-- If applicable, add screenshots or examples to help explain your changes. -->
Before Change:

After first round of accumulation and gather task you will get this error and full stop the process.


```
Unhandled exception in miner: Expected all tensors to be on the same device, but found at least two devices,
           cuda:2 and cuda:0!                                                                                         │
           │ /home/cvm/templar/src/tplr/compress.py:320 in _dequantize_values                                          │
           │                                                                                                           │
           │   317 │   │   dequantized = lookup[val.long()]                                                            │
           │   318 │   │                                                                                               │
           │   319 │   │   # Apply scale and shift to get back original distribution                                   │
           │ ❱ 320 │   │   val = dequantized + shift                                                                   │
           │   321 │   │   val = val.to(orig_dtype)                                                                    │
           │   322 │   │                                                                                               │
           │   323 │   │   return val                                                                                  │

           RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:2 and
           cuda:0!
```
 
    
After Change:
           
Miner is able to dequantize as expected. 
           
This change ensures that the shift tensor is moved to the same device as dequantized before performing operations on them.


## Additional Notes
<!-- Add any other context about the PR here. -->
