### PR TITLE
Add world_size check for dist.broadcast() calls

### DIFF
--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -816,13 +816,15 @@ class Miner:
                 self.optimizer.step()
                 self.scheduler.step()
                 torch.cuda.empty_cache()
-                for t in bare_model.state_dict().values():
-                    if torch.is_tensor(t):
-                        dist.broadcast(t.data, src=0)
+                if self.world_size > 1:
+                    for t in bare_model.state_dict().values():
+                        if torch.is_tensor(t):
+                            dist.broadcast(t.data, src=0)
             else:
-                for t in bare_model.state_dict().values():
-                    if torch.is_tensor(t):
-                        dist.broadcast(t.data, src=0)
+                if self.world_size > 1:
+                    for t in bare_model.state_dict().values():
+                        if torch.is_tensor(t):
+                            dist.broadcast(t.data, src=0)
 
             tplr.logger.info(
                 f"{tplr.P(step_window, tplr.T() - update_start)} Updated model"


### PR DESCRIPTION
## Description
**Problem**: The miner crashes with `ValueError: Default process group has not been initialized` when running on a single GPU because `dist.broadcast()` is called without checking if distributed training is enabled.

**Root cause**: The code was calling `dist.broadcast()` to sync model parameters across ranks, but this only makes sense when `world_size > 1`. For single-GPU runs, there's no process group initialized and nothing to sync.

https://github.com/tplr-ai/templar/blob/0b68cbc2a0d032371ecec7caaca5570b7a91afee/neurons/miner.py#L819-L825

Neither of the `dist.broadcast()` calls above verify that the miner is being run in a setup that requires synchronization across multiple gpus. 

**Fix**: Added `if self.world_size > 1:` guards around the `dist.broadcast()` calls in the model update section.

This enables the miner to run properly on single-GPU setups.

## Type of Change
<!-- Check the relevant option(s): -->
- [ ] Feature (adding new functionality)
- [x] Fix (resolving a bug or issue)
- [ ] Docs (documentation updates)
- [ ] Refactor (code changes that don't affect functionality)
- [ ] Maintenance (dependency updates or other maintenance)
- [ ] Tests (adding or improving tests)
- [ ] Breaking change (fix or feature with incompatible API changes)
- [ ] Other: _____

## Branch Naming
<!-- Confirm your branch follows the naming convention: <kind>/<description> -->
- [x] My branch follows the project's naming convention (e.g., feature/add-new-capability)

## Commit Messages
<!-- Ensure your commits follow the project guidelines -->
- [x] My commits are small, atomic, and have proper commit messages
- [x] Commit messages are in imperative mood with a capitalized summary under 50 chars

## Additional Notes
Here's the full error trace with previous debug log for context
```
[21:56:20] 536762 (17.01s) Downloaded peer gradients <--                        
           536762 (0.54s) Processed peer gradients <--                          
           Gather done in 17.55s. Success rate: 15/15, Upload: 0 bytes,         
           Download: 2551818240 bytes                                           
           Gather task completed!                                               
Traceback (most recent call last):
  File "/workspace/templar-miner-0/neurons/miner.py", line 1058, in <module>
    asyncio.run(Miner().run())
  File "/root/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/root/.local/share/uv/python/cpython-3.11.13-linux-x86_64-gnu/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
  File "/workspace/templar-miner-0/neurons/miner.py", line 821, in run
    dist.broadcast(t.data, src=0)
  File "/workspace/templar-miner-0/.venv/lib/python3.11/site-packages/torch/distributed/c10d_logger.py", line 81, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/templar-miner-0/.venv/lib/python3.11/site-packages/torch/distributed/distributed_c10d.py", line 2715, in broadcast
    group = _group_or_default_group(group)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspace/templar-miner-0/.venv/lib/python3.11/site-packages/torch/distributed/distributed_c10d.py", line 1140, in _group_or_default_group
    group = _get_default_group()
            ^^^^^^^^^^^^^^^^^^^^
  File "/workspace/templar-miner-0/.venv/lib/python3.11/site-packages/torch/distributed/distributed_c10d.py", line 1302, in _get_default_group
    raise ValueError(
ValueError: Default process group has not been initialized, please make sure to call init_process_group.
```
